### PR TITLE
[Feat #24] 기업 서버에 로깅 추가, JWT 파싱 로직 추가

### DIFF
--- a/jobbotdari/src/main/java/com/team9/jobbotdari/aspect/LoggingAspect.java
+++ b/jobbotdari/src/main/java/com/team9/jobbotdari/aspect/LoggingAspect.java
@@ -1,0 +1,102 @@
+package com.team9.jobbotdari.aspect;
+
+import com.team9.jobbotdari.entity.Log;
+import com.team9.jobbotdari.repository.LogRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LoggingAspect {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingAspect.class);
+    private final LogRepository logRepository;
+
+    @Around("execution(* com.team9.jobbotdari.controller..*(..)) " +
+            "|| execution(* com.team9.jobbotdari.service..*(..)) " +
+            "|| execution(* com.team9.jobbotdari.repository..*(..))")
+    public Object logAllLayers(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        String className = joinPoint.getTarget().getClass().getSimpleName();
+        String methodName = methodSignature.getMethod().getName();
+        String args = Arrays.toString(joinPoint.getArgs());
+
+        Long userId = getCurrentUserId();
+
+        String enterAction = "ENTER: " + className + "." + methodName;
+        String enterDescription = "Arguments: " + args;
+        Log enterLog = Log.builder()
+                .userId(userId)
+                .action(enterAction)
+                .description(enterDescription)
+                .build();
+        logRepository.save(enterLog);
+        log.info("[LOG] Action: {}", enterAction);
+        log.info("[LOG] Description: {}", enterDescription);
+
+        Object result = joinPoint.proceed();
+        long duration = System.currentTimeMillis() - startTime;
+
+        String exitAction = "EXIT: " + className + "." + methodName;
+        String exitDescription = "Execution time: " + duration + "ms; Returned: " + result;
+        Log exitLog = Log.builder()
+                .userId(userId)
+                .action(exitAction)
+                .description(exitDescription)
+                .build();
+        logRepository.save(exitLog);
+        log.info("[LOG] Action: {}", exitAction);
+        log.info("[LOG] Description: {}", exitDescription);
+
+        return result;
+    }
+
+    private Long getCurrentUserId() {
+        try {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes == null) {
+                return null;
+            }
+            HttpServletRequest request = attributes.getRequest();
+            String authHeader = request.getHeader("Authorization");
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                String token = authHeader.substring(7);
+                String[] parts = token.split("\\.");
+                if (parts.length < 2) {
+                    return null;
+                }
+                String payload = parts[1];
+                byte[] decodedBytes = Base64.getUrlDecoder().decode(payload);
+                String jsonPayload = new String(decodedBytes, StandardCharsets.UTF_8);
+                ObjectMapper mapper = new ObjectMapper();
+                Map<String, Object> claims = mapper.readValue(jsonPayload, Map.class);
+                Object userIdObj = claims.get("userId");
+                if (userIdObj != null) {
+                    return Long.parseLong(userIdObj.toString());
+                }
+            }
+        } catch (Exception e) {
+            log.warn("UserId 추출 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+}
+

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/controller/UserInterestController.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/controller/UserInterestController.java
@@ -1,0 +1,24 @@
+package com.team9.jobbotdari.controller;
+
+import com.team9.jobbotdari.dto.request.AddInterestRequest;
+import com.team9.jobbotdari.service.UserInterestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user/interests")
+@RequiredArgsConstructor
+public class UserInterestController {
+
+    private final UserInterestService userInterestService;
+
+    @PostMapping
+    public ResponseEntity<String> addInterest(@RequestBody AddInterestRequest addInterestRequest) {
+        userInterestService.addUserInterest(addInterestRequest);
+        return ResponseEntity.ok("관심 기업 추가 완료");
+    }
+}

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/dto/request/AddInterestRequest.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/dto/request/AddInterestRequest.java
@@ -1,0 +1,8 @@
+package com.team9.jobbotdari.dto.request;
+
+import lombok.Data;
+
+@Data
+public class AddInterestRequest {
+    private Long companyId;
+}

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/exception/base/ExceptionCode.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/exception/base/ExceptionCode.java
@@ -15,7 +15,10 @@ public enum ExceptionCode {
 
     // 회원가입 관련 오류 추가
     DUPLICATE_USERNAME(409, "USER_001", "이미 사용 중인 아이디입니다."),
-    PASSWORD_MISMATCH(400, "USER_002", "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+    PASSWORD_MISMATCH(400, "USER_002", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+
+    // 관심기업 관련 오류 추가
+    DUPLICATE_USER_INTEREST(409, "USER_INTEREST_001", "이미 관심기업 목록에 존재합니다.");
 
     /**
      *

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/exception/userinterest/DuplicateUserInterestException.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/exception/userinterest/DuplicateUserInterestException.java
@@ -1,0 +1,10 @@
+package com.team9.jobbotdari.exception.userinterest;
+
+import com.team9.jobbotdari.exception.base.BusinessException;
+import com.team9.jobbotdari.exception.base.ExceptionCode;
+
+public class DuplicateUserInterestException extends BusinessException {
+    public DuplicateUserInterestException () {
+        super(ExceptionCode.DUPLICATE_USER_INTEREST);
+    }
+}

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/repository/UserInterestRepository.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/repository/UserInterestRepository.java
@@ -1,7 +1,9 @@
 package com.team9.jobbotdari.repository;
 
+import com.team9.jobbotdari.entity.User;
 import com.team9.jobbotdari.entity.UserInterest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
+    boolean existsByUserAndCompanyId(User user, Long companyId);
 }

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/service/UserInterestService.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/service/UserInterestService.java
@@ -1,0 +1,46 @@
+package com.team9.jobbotdari.service;
+
+import com.team9.jobbotdari.dto.request.AddInterestRequest;
+import com.team9.jobbotdari.entity.User;
+import com.team9.jobbotdari.entity.UserInterest;
+import com.team9.jobbotdari.exception.user.UserNotFoundException;
+import com.team9.jobbotdari.exception.userinterest.DuplicateUserInterestException;
+import com.team9.jobbotdari.repository.UserInterestRepository;
+import com.team9.jobbotdari.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserInterestService {
+
+    private final UserInterestRepository userInterestRepository;
+
+    public void addUserInterest(AddInterestRequest addInterestRequest) {
+        User user = getCurrentUser();
+        if (user == null) {
+            throw new UserNotFoundException();
+        }
+
+        boolean exists = userInterestRepository.existsByUserAndCompanyId(user, addInterestRequest.getCompanyId());
+        if (exists) {
+            throw new DuplicateUserInterestException();
+        }
+        UserInterest userInterest = UserInterest.builder()
+                .user(user)
+                .companyId(addInterestRequest.getCompanyId())
+                .build();
+        userInterestRepository.save(userInterest);
+    }
+
+    private User getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails) {
+            CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+            return customUserDetails.getUser();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
전의 유저 서버에서의 로깅과 비슷한 로깅 기업 서버에 적용하였습니다.
변경사항은 원래 SecurityContext에서 유저 정보를 얻던 것과는 다르게 JWT 토큰을 디코딩하여 userId를 삽입하였습니다.