### PR TITLE
[Feat #40] dockerfile 및 docker-compose.yml 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 jobbotdari/HELP.md
 .gradle
+.env
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/configserver/Dockerfile
+++ b/configserver/Dockerfile
@@ -1,0 +1,11 @@
+# config-server/Dockerfile
+FROM gradle:8.12.1-jdk21 AS builder
+WORKDIR /home/gradle/project
+COPY --chown=gradle:gradle . .
+RUN gradle build --no-daemon
+
+FROM openjdk:21-jdk-slim
+VOLUME /tmp
+COPY --from=builder /home/gradle/project/build/libs/*.jar app.jar
+EXPOSE 8071
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/configserver/Dockerfile
+++ b/configserver/Dockerfile
@@ -5,6 +5,7 @@ COPY --chown=gradle:gradle . .
 RUN gradle build --no-daemon
 
 FROM openjdk:21-jdk-slim
+RUN apt-get update && apt-get install -y curl
 VOLUME /tmp
 COPY --from=builder /home/gradle/project/build/libs/*.jar app.jar
 EXPOSE 8071

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,11 @@ services:
     container_name: config-server
     ports:
       - "8071:8071"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8071/actuator/health" ]
+      interval: 5s
+      retries: 5
+      start_period: 30s
     environment:
       - SPRING_APPLICATION_NAME=config-server
       - SPRING_PROFILES_ACTIVE=git
@@ -43,7 +48,8 @@ services:
       - SPRING_APPLICATION_NAME=eureka-server
       - SPRING_PROFILES_ACTIVE=default
     depends_on:
-      - config-server
+      config-server:
+        condition: service_healthy
     networks:
       - app-network
 
@@ -72,7 +78,7 @@ services:
     environment:
       - SPRING_APPLICATION_NAME=jobbotdari
       - SPRING_PROFILES_ACTIVE=default
-      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/jobbotdari_db?serverTimezone=UTC
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/news_db?serverTimezone=UTC
       - SPRING_DATASOURCE_USERNAME=springboot
       - SPRING_DATASOURCE_PASSWORD=p@ssw0rd
     depends_on:
@@ -81,7 +87,7 @@ services:
     networks:
       - app-network
 
-  jobbotdari_user:
+  jobbotdari-user:
     build:
       context: ./jobbotdari_user
       dockerfile: Dockerfile
@@ -91,7 +97,7 @@ services:
     environment:
       - SPRING_APPLICATION_NAME=jobbotdari-user
       - SPRING_PROFILES_ACTIVE=default
-      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/user_db?serverTimezone=UTC
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/news_db?serverTimezone=UTC
       - SPRING_DATASOURCE_USERNAME=springboot
       - SPRING_DATASOURCE_PASSWORD=p@ssw0rd
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,111 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql
+    container_name: mysql
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=1234
+      - MYSQL_DATABASE=news_db
+      - MYSQL_USER=springboot
+      - MYSQL_PASSWORD=p@ssw0rd
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    networks:
+      - app-network
+  config-server:
+    build:
+      context: ./configserver
+      dockerfile: Dockerfile
+    container_name: config-server
+    ports:
+      - "8071:8071"
+    environment:
+      - SPRING_APPLICATION_NAME=config-server
+      - SPRING_PROFILES_ACTIVE=git
+      - GIT_USERNAME=${GIT_USERNAME}
+      - GIT_PW=${GIT_PW}
+    networks:
+      - app-network
+
+  eureka-server:
+    build:
+      context: ./eurekaserver
+      dockerfile: Dockerfile
+    container_name: eureka-server
+    ports:
+      - "8070:8070"
+    environment:
+      - SPRING_APPLICATION_NAME=eureka-server
+      - SPRING_PROFILES_ACTIVE=default
+    depends_on:
+      - config-server
+    networks:
+      - app-network
+
+  gateway-server:
+    build:
+      context: ./gatewayserver
+      dockerfile: Dockerfile
+    container_name: gateway-server
+    ports:
+      - "8072:8072"
+    environment:
+      - SPRING_APPLICATION_NAME=gateway-server
+      - SPRING_PROFILES_ACTIVE=default
+    depends_on:
+      - eureka-server
+    networks:
+      - app-network
+
+  jobbotdari:
+    build:
+      context: ./jobbotdari
+      dockerfile: Dockerfile
+    container_name: jobbotdari
+    ports:
+      - "8081:8081"
+    environment:
+      - SPRING_APPLICATION_NAME=jobbotdari
+      - SPRING_PROFILES_ACTIVE=default
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/jobbotdari_db?serverTimezone=UTC
+      - SPRING_DATASOURCE_USERNAME=springboot
+      - SPRING_DATASOURCE_PASSWORD=p@ssw0rd
+    depends_on:
+      - eureka-server
+      - mysql
+    networks:
+      - app-network
+
+  jobbotdari_user:
+    build:
+      context: ./jobbotdari_user
+      dockerfile: Dockerfile
+    container_name: jobbotdari-user
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_APPLICATION_NAME=jobbotdari-user
+      - SPRING_PROFILES_ACTIVE=default
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/user_db?serverTimezone=UTC
+      - SPRING_DATASOURCE_USERNAME=springboot
+      - SPRING_DATASOURCE_PASSWORD=p@ssw0rd
+    depends_on:
+      - eureka-server
+      - mysql
+    networks:
+      - app-network
+    volumes:
+      - jobbotdari-user-uploads:/app/uploads
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  mysql-data:
+  jobbotdari-user-uploads:

--- a/eurekaserver/Dockerfile
+++ b/eurekaserver/Dockerfile
@@ -1,0 +1,11 @@
+# eureka-server/Dockerfile
+FROM gradle:8.12.1-jdk21 AS builder
+WORKDIR /home/gradle/project
+COPY --chown=gradle:gradle . .
+RUN gradle build --no-daemon
+
+FROM openjdk:21-jdk-slim
+VOLUME /tmp
+COPY --from=builder /home/gradle/project/build/libs/*.jar app.jar
+EXPOSE 8070
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/eurekaserver/src/main/resources/application.yml
+++ b/eurekaserver/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   application:
     name: eureka-server
   config:
-    import: "optional:configserver:http://localhost:8071"
+    import: "optional:configserver:http://config-server:8071"

--- a/gatewayserver/Dockerfile
+++ b/gatewayserver/Dockerfile
@@ -1,0 +1,11 @@
+# gateway/Dockerfile
+FROM gradle:8.12.1-jdk21 AS builder
+WORKDIR /home/gradle/project
+COPY --chown=gradle:gradle . .
+RUN gradle build --no-daemon
+
+FROM openjdk:21-jdk-slim
+VOLUME /tmp
+COPY --from=builder /home/gradle/project/build/libs/*.jar app.jar
+EXPOSE 8072
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/gatewayserver/src/main/resources/application.yml
+++ b/gatewayserver/src/main/resources/application.yml
@@ -4,4 +4,4 @@ spring:
   application:
     name: gateway-server
   config:
-    import: "optional:configserver:http://localhost:8071"
+    import: "optional:configserver:http://config-server:8071"

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,56 @@
+CREATE TABLE users (
+                       id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                       name VARCHAR(255) NOT NULL,
+                       username VARCHAR(255) UNIQUE NOT NULL,
+                       password VARCHAR(255) NOT NULL,
+                       role VARCHAR(50) NOT NULL,
+                       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE company (
+                         id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                         name VARCHAR(255) NOT NULL,
+                         description TEXT,
+                         website_url VARCHAR(255),
+                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE recruitment (
+                             id BIGINT PRIMARY KEY,
+                             company_id BIGINT NOT NULL,
+                             title VARCHAR(255) NOT NULL,
+                             requirements VARCHAR(255),
+                             description TEXT,
+                             deadline TIMESTAMP,
+                             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                             FOREIGN KEY (company_id) REFERENCES company(id) ON DELETE CASCADE
+);
+
+CREATE TABLE user_interests (
+                                id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                                user_id BIGINT NOT NULL,
+                                company_id BIGINT NOT NULL,
+                                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+                                FOREIGN KEY (company_id) REFERENCES company(id) ON DELETE CASCADE
+);
+
+CREATE TABLE files (
+                       id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                       user_id BIGINT NOT NULL,
+                       filename VARCHAR(255) NOT NULL,
+                       file_path VARCHAR(255) NOT NULL,
+                       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE logs (
+                      id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                      user_id BIGINT NULL,
+                      action VARCHAR(255) NOT NULL,
+                      description TEXT,
+                      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/jobbotdari/Dockerfile
+++ b/jobbotdari/Dockerfile
@@ -1,0 +1,11 @@
+# jobbotdari/Dockerfile
+FROM gradle:8.12.1-jdk21 AS builder
+WORKDIR /home/gradle/project
+COPY --chown=gradle:gradle . .
+RUN gradle build --no-daemon
+
+FROM openjdk:21-jdk-slim
+VOLUME /tmp
+COPY --from=builder /home/gradle/project/build/libs/*.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/jobbotdari/Dockerfile
+++ b/jobbotdari/Dockerfile
@@ -2,7 +2,7 @@
 FROM gradle:8.12.1-jdk21 AS builder
 WORKDIR /home/gradle/project
 COPY --chown=gradle:gradle . .
-RUN gradle build --no-daemon
+RUN gradle build --no-daemon -x test
 
 FROM openjdk:21-jdk-slim
 VOLUME /tmp

--- a/jobbotdari/src/main/resources/application.yml
+++ b/jobbotdari/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   application:
     name: jobbotdari
   config:
-    import: "optional:configserver:http://localhost:8071"
+    import: "optional:configserver:http://config-server:8071"

--- a/jobbotdari_user/Dockerfile
+++ b/jobbotdari_user/Dockerfile
@@ -1,0 +1,11 @@
+# jobbotdari-user/Dockerfile
+FROM gradle:8.12.1-jdk21 AS builder
+WORKDIR /home/gradle/project
+COPY --chown=gradle:gradle . .
+RUN gradle build --no-daemon
+
+FROM openjdk:21-jdk-slim
+VOLUME /tmp
+COPY --from=builder /home/gradle/project/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app.jar", "--spring.profiles.active=prod"]

--- a/jobbotdari_user/Dockerfile
+++ b/jobbotdari_user/Dockerfile
@@ -2,7 +2,7 @@
 FROM gradle:8.12.1-jdk21 AS builder
 WORKDIR /home/gradle/project
 COPY --chown=gradle:gradle . .
-RUN gradle build --no-daemon
+RUN gradle build --no-daemon -x test
 
 FROM openjdk:21-jdk-slim
 VOLUME /tmp

--- a/jobbotdari_user/src/main/resources/application.properties
+++ b/jobbotdari_user/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=jobbotdari-user
-spring.config.import=optional:configserver:http://localhost:8071
+spring.config.import=optional:configserver:http://config-server:8071

--- a/jobbotdari_user/src/main/resources/application.properties
+++ b/jobbotdari_user/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-spring.application.name=jobbotdari_user
+spring.application.name=jobbotdari-user
 spring.config.import=optional:configserver:http://localhost:8071


### PR DESCRIPTION
`docker compose up -d` 로 실행

1. mysql 컨테이너명으로 db 설정 통일, 각 서버에 존재하던 datasource 삭제, compose에서 관리
2. 각 컨테이너명으로 통신
3. docker compose에서 서버 설정파일 받기 위해 health check 로직 추가