### PR TITLE
[Hotfix #46] 로그 조회 시 발생하는 오류 수정 

### DIFF
--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/entity/Log.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/entity/Log.java
@@ -24,7 +24,7 @@ public class Log {
     private User user;
 
     private String action;
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "LONGTEXT")
     private String description;
 
     @CreationTimestamp

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/repository/LogRepository.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/repository/LogRepository.java
@@ -1,12 +1,16 @@
 package com.team9.jobbotdari.repository;
 
 import com.team9.jobbotdari.entity.Log;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.domain.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface LogRepository extends JpaRepository<Log, Long> {
     List<Log> findByCreatedAtAfter(LocalDateTime date);
+
+    Page<Log> findAll(Pageable pageable);
 }
 

--- a/jobbotdari_user/src/main/java/com/team9/jobbotdari/service/AdminServiceImpl.java
+++ b/jobbotdari_user/src/main/java/com/team9/jobbotdari/service/AdminServiceImpl.java
@@ -10,6 +10,9 @@ import com.team9.jobbotdari.repository.LogRepository;
 import com.team9.jobbotdari.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -42,7 +45,9 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     public List<LogListResponseDto> getLogs() {
-        List<Log> logs = logRepository.findAll();
+        Pageable pageable = (Pageable) PageRequest.of(0, 10);
+        Page<Log> logPages = logRepository.findAll(pageable);
+        List<Log> logs = logPages.getContent();
 
         return logs.stream()
                 .map(log -> LogListResponseDto.builder()


### PR DESCRIPTION
## 작업 내용 
- 로그 조회 시 MySQL max_allowed_packet이 발생하여, Paging 처리를 넣었습니다. ([오류 내용 노션 확인](https://www.notion.so/jiminh00/19ab78edc863806a86ddf2f78b8b515c?pvs=4#1a5b78edc86380cda3a3c5b149de91d7))  
- _추후 시간이 남으면_ API 역시 페이징 처리에 맞게 수정해보겠습니다. 